### PR TITLE
Make changes needed for two-device support in scoutfs

### DIFF
--- a/common/dmflakey
+++ b/common/dmflakey
@@ -28,6 +28,7 @@ fi
 
 _init_flakey()
 {
+	_scratch_mkfs > /dev/null
 	local BLK_DEV_SIZE=`blockdev --getsz $SCRATCH_DEV`
 	FLAKEY_DEV=/dev/mapper/flakey-test
 	FLAKEY_TABLE="0 $BLK_DEV_SIZE flakey $SCRATCH_DEV 0 180 0"
@@ -40,7 +41,12 @@ _init_flakey()
 _mount_flakey()
 {
 	_scratch_options mount
-	mount -t $FSTYP $SCRATCH_OPTIONS $MOUNT_OPTIONS $FLAKEY_DEV $SCRATCH_MNT
+	if [ "$FSTYP" == "scoutfs" ]; then
+	    mount -t $FSTYP $SCRATCH_OPTIONS $SCOUTFS_SCRATCH_MOUNT_OPTIONS $FLAKEY_DEV $SCRATCH_MNT
+	    return
+	fi
+
+	mount -t $FSTYP $SCRATCH_OPTIONS $SCRATCH_MOUNT_OPTIONS $FLAKEY_DEV $SCRATCH_MNT
 }
 
 _unmount_flakey()

--- a/common/rc
+++ b/common/rc
@@ -257,12 +257,23 @@ _overlay_mount_options()
 	     $OVERLAY_MOUNT_OPTIONS
 }
 
+_scoutfs_mount_options()
+{
+	echo "$SCOUTFS_SCRATCH_MOUNT_OPTIONS $*" \
+	     "$SCRATCH_DEV" \
+	     "$SCRATCH_MNT"
+}
+
 _scratch_mount_options()
 {
 	_scratch_options mount
 
 	if [ "$FSTYP" == "overlay" ]; then
 		echo `_overlay_mount_options $SCRATCH_DEV`
+		return 0
+	fi
+	if [ "$FSTYP" == "scoutfs" ]; then
+		echo `_scoutfs_mount_options $*`
 		return 0
 	fi
 	echo `_common_dev_mount_options $*` $SCRATCH_OPTIONS \
@@ -824,7 +835,7 @@ _scratch_mkfs()
         $MKFS_F2FS_PROG $MKFS_OPTIONS $* $SCRATCH_DEV > /dev/null
 	;;
     scoutfs)
-	$SCOUTFS_PROG mkfs $MKFS_OPTIONS $* $SCRATCH_DEV
+	$SCOUTFS_PROG mkfs $MKFS_OPTIONS $* $SCRATCH_META_DEV $SCRATCH_DEV
 	;;
     *)
 	yes | $MKFS_PROG -t $FSTYP -- $MKFS_OPTIONS $* $SCRATCH_DEV


### PR DESCRIPTION
I'm seeing sporadic failures of tests with this:

```
run 1 generic/067 generic/069 generic/071 generic/073
run 2 generic/041 generic/067 generic/098 generic/101
run 3 generic/057 generic/067 generic/069 generic/071 generic/073
run 4 generic/041 generic/104 generic/307
```

but I'm also seeing sporadic failures withOUT this:

```
run 1 generic/067 generic/069 generic/071 generic/073 generic/342 generic/343
run 2 generic/041 generic/098 generic/101 generic/322 generic/335
run 3 generic/041 generic/071 generic/322 generic/335 generic/336 generic/343
run 4 generic/040 generic/067 generic/071 generic/098 generic/101 generic/307 generic/322 generic/335
```

Therefore I conclude it's not this PR's job to fix.