### PR TITLE
Add scoutfs per-fs mkfs options

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -732,7 +732,7 @@ _test_mkfs()
 	$MKFS_PROG -t $FSTYP -- -F $MKFS_OPTIONS $* $TEST_DEV
 	;;
     scoutfs)
-	$SCOUTFS_PROG mkfs -f $MKFS_OPTIONS $* $TEST_DEV
+	$SCOUTFS_PROG mkfs $MKFS_OPTIONS $MKFS_TEST_OPTIONS $* $TEST_DEV
 	;;
     *)
 	yes | $MKFS_PROG -t $FSTYP -- $MKFS_OPTIONS $* $TEST_DEV
@@ -760,7 +760,7 @@ _mkfs_dev()
 		2>$tmp_dir.mkfserr 1>$tmp_dir.mkfsstd
 	;;
     scoutfs)
-        $SCOUTFS_PROG mkfs -f $MKFS_OPTIONS $* 2>$tmp_dir.mkfserr 1>$tmp_dir.mkfsstd
+        $SCOUTFS_PROG mkfs $MKFS_OPTIONS $MKFS_DEV_OPTIONS $* 2>$tmp_dir.mkfserr 1>$tmp_dir.mkfsstd
 	;;
 
     *)
@@ -835,7 +835,7 @@ _scratch_mkfs()
         $MKFS_F2FS_PROG $MKFS_OPTIONS $* $SCRATCH_DEV > /dev/null
 	;;
     scoutfs)
-	$SCOUTFS_PROG mkfs -f $MKFS_OPTIONS $* $SCRATCH_META_DEV $SCRATCH_DEV
+	$SCOUTFS_PROG mkfs $MKFS_OPTIONS $MKFS_SCRATCH_OPTIONS $* $SCRATCH_META_DEV $SCRATCH_DEV
 	;;
     *)
 	yes | $MKFS_PROG -t $FSTYP -- $MKFS_OPTIONS $* $SCRATCH_DEV


### PR DESCRIPTION
ScoutFS requires unique addresses for each quorum member slot for each
file system.  We add _TEST_, _SCRATCH_, and _DEV_ mkfs options for each
kind of fs that tests are going to try and make.  We also remove the
unconditional -f so that the config can put it in MKFS_OPTIONS.

Signed-off-by: Zach Brown <zab@versity.com>