### PR TITLE
RHEL8 support

### DIFF
--- a/src/fssum.c
+++ b/src/fssum.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #ifdef __SOLARIS__
 #include <sys/mkdev.h>
 #endif

--- a/tests/generic/062
+++ b/tests/generic/062
@@ -47,7 +47,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 getfattr()
 {
-    $GETFATTR_PROG --absolute-names -dh $@ 2>&1 | _filter_scratch
+    $GETFATTR_PROG --absolute-names -dh $@ 2>&1 | _filter_scratch | sed 's/=""$//'
 }
 
 setfattr()


### PR DESCRIPTION
These 2 changes are needed to (1) compile on RHEL8-based systems and (2) handle subtle differences in `getfattr` output formatting. They are both related to upstream changes that are present in `master`.